### PR TITLE
fix(keyreg): decode online participation keys to Uint8Array for algosdk v3 [PERA-4445]

### DIFF
--- a/src/core/home/sign-txn/create/button/CreateTxnButton.tsx
+++ b/src/core/home/sign-txn/create/button/CreateTxnButton.tsx
@@ -176,11 +176,13 @@ const CreateTxnButton = ({
       let txn: Transaction;
 
       if (isOnlineKeyregTxn) {
+        // algosdk v3 requires participation keys as raw bytes; the form
+        // provides them as base64 strings, so decode at the boundary.
         txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
           sender: address,
-          voteKey: voteKey!,
-          selectionKey: selectionKey!,
-          stateProofKey: stateProofKey!,
+          voteKey: new Uint8Array(Buffer.from(voteKey!, "base64")),
+          selectionKey: new Uint8Array(Buffer.from(selectionKey!, "base64")),
+          stateProofKey: new Uint8Array(Buffer.from(stateProofKey!, "base64")),
           voteFirst: suggestedParams.firstValid,
           voteLast: suggestedParams.lastValid,
           voteKeyDilution: voteKeyDilution!,

--- a/src/core/home/sign-txn/create/button/CreateTxnButton.tsx
+++ b/src/core/home/sign-txn/create/button/CreateTxnButton.tsx
@@ -180,9 +180,9 @@ const CreateTxnButton = ({
         // provides them as base64 strings, so decode at the boundary.
         txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
           sender: address,
-          voteKey: new Uint8Array(Buffer.from(voteKey!, "base64")),
-          selectionKey: new Uint8Array(Buffer.from(selectionKey!, "base64")),
-          stateProofKey: new Uint8Array(Buffer.from(stateProofKey!, "base64")),
+          voteKey: algosdk.base64ToBytes(voteKey!),
+          selectionKey: algosdk.base64ToBytes(selectionKey!),
+          stateProofKey: algosdk.base64ToBytes(stateProofKey!),
           voteFirst: suggestedParams.firstValid,
           voteLast: suggestedParams.lastValid,
           voteKeyDilution: voteKeyDilution!,

--- a/src/scenarios/builders/keyreg.ts
+++ b/src/scenarios/builders/keyreg.ts
@@ -1,5 +1,10 @@
 import algosdk, { type Address, type SuggestedParams } from "algosdk";
 
+// algosdk v3 requires participation keys as raw bytes (v2 accepted base64
+// strings). Decode at the boundary so scenarios can keep using base64 literals.
+const base64ToBytes = (value: string): Uint8Array =>
+  new Uint8Array(Buffer.from(value, "base64"));
+
 export interface BuildOnlineKeyregArgs {
   sender: string | Address;
   voteKey: string;
@@ -9,19 +14,21 @@ export interface BuildOnlineKeyregArgs {
   voteLast: number;
   voteKeyDilution: number;
   note?: string;
+  rekeyTo?: string | Address;
   suggestedParams: SuggestedParams;
 }
 
 export const buildOnlineKeyreg = (args: BuildOnlineKeyregArgs): algosdk.Transaction => {
   return algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
     sender: args.sender,
-    voteKey: args.voteKey,
-    selectionKey: args.selectionKey,
-    stateProofKey: args.stateProofKey,
+    voteKey: base64ToBytes(args.voteKey),
+    selectionKey: base64ToBytes(args.selectionKey),
+    stateProofKey: base64ToBytes(args.stateProofKey),
     voteFirst: args.voteFirst,
     voteLast: args.voteLast,
     voteKeyDilution: args.voteKeyDilution,
     note: args.note ? new Uint8Array(Buffer.from(args.note)) : undefined,
+    ...(args.rekeyTo ? { rekeyTo: args.rekeyTo } : {}),
     suggestedParams: args.suggestedParams
   });
 };

--- a/src/scenarios/builders/keyreg.ts
+++ b/src/scenarios/builders/keyreg.ts
@@ -1,10 +1,5 @@
 import algosdk, { type Address, type SuggestedParams } from "algosdk";
 
-// algosdk v3 requires participation keys as raw bytes (v2 accepted base64
-// strings). Decode at the boundary so scenarios can keep using base64 literals.
-const base64ToBytes = (value: string): Uint8Array =>
-  new Uint8Array(Buffer.from(value, "base64"));
-
 export interface BuildOnlineKeyregArgs {
   sender: string | Address;
   voteKey: string;
@@ -21,9 +16,11 @@ export interface BuildOnlineKeyregArgs {
 export const buildOnlineKeyreg = (args: BuildOnlineKeyregArgs): algosdk.Transaction => {
   return algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
     sender: args.sender,
-    voteKey: base64ToBytes(args.voteKey),
-    selectionKey: base64ToBytes(args.selectionKey),
-    stateProofKey: base64ToBytes(args.stateProofKey),
+    // algosdk v3 requires participation keys as raw bytes (v2 accepted base64
+    // strings), so decode the base64 literals at the boundary.
+    voteKey: algosdk.base64ToBytes(args.voteKey),
+    selectionKey: algosdk.base64ToBytes(args.selectionKey),
+    stateProofKey: algosdk.base64ToBytes(args.stateProofKey),
     voteFirst: args.voteFirst,
     voteLast: args.voteLast,
     voteKeyDilution: args.voteKeyDilution,

--- a/src/scenarios/groups/single-keyreg.ts
+++ b/src/scenarios/groups/single-keyreg.ts
@@ -45,7 +45,7 @@ export const singleKeyregScenarios: Scenario[] = [
     async build(chain, address) {
       const suggestedParams = await apiGetTxnParams(chain);
       const voteFirst = Number(suggestedParams.firstValid);
-      const txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
+      const txn = buildOnlineKeyreg({
         sender: address,
         voteKey: "G/lqTV6MKspW6J8wH2d8ZliZ5XZVZsruqSBJMwLwlmo=",
         selectionKey: "LrpLhvzr+QpN/bivh6IPpOaKGbGzTTB5lJtVfixmmgg=",
@@ -53,7 +53,7 @@ export const singleKeyregScenarios: Scenario[] = [
         voteFirst,
         voteLast: voteFirst + 1000,
         voteKeyDilution: 100,
-        note: new Uint8Array(Buffer.from("single-keyreg-online-with-rekey")),
+        note: "single-keyreg-online-with-rekey",
         rekeyTo: testAccounts[1].addr,
         suggestedParams
       });


### PR DESCRIPTION
# Pull Request Template

## Description
The online key-registration scenarios failed with `voteKey must be a 32 byte Uint8Array` before the request ever reached the wallet. `algosdk` was upgraded to v3 (2024-12-03), which requires participation keys as `Uint8Array`, but the online keyreg code still passed them as base64 `string`s — a leftover from the v2 API. This decodes the keys to bytes at the algosdk boundary, so the base64 literals and form inputs stay as-is.

Changes:
- `buildOnlineKeyreg` decodes `voteKey` / `selectionKey` / `stateProofKey` via a `base64ToBytes` helper, and gains an optional `rekeyTo`.
- The `single-keyreg-online-with-rekey` scenario now reuses `buildOnlineKeyreg` instead of an inline duplicate of the same call.
- The manual "Create → online keyreg" form decodes its base64 text-input keys.

Offline keyreg and the payment/asset/application builders were unaffected (they pass no participation keys). Verified on-device: online keyreg now builds, reaches the Pera signing screen, signs, and submits — an unfunded account returns `overspend`, exactly like a plain payment.

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-4445

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
