### PR TITLE
fix: hide network selector host caption on mobile so the connect button stays visible

### DIFF
--- a/src/core/home/network-selector/NetworkSelector.tsx
+++ b/src/core/home/network-selector/NetworkSelector.tsx
@@ -71,6 +71,7 @@ const NetworkSelector = ({chain, onChange}: NetworkSelectorProps) => {
           <Typography
             variant={"caption"}
             sx={{
+              display: {xs: "none", sm: "block"},
               opacity: 0.7,
               lineHeight: 1.2,
               maxWidth: 220,


### PR DESCRIPTION


## Description
Fixes the header overflow on phone-width screens (Samsung S25, iPhone 17 Pro) where the Connect button was pushed off-screen.

## Related Issues
- https://algorandfoundation.atlassian.net/browse/PERA-4755

## Checklist
- [x] Have you tested your changes locally?
- [x] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?
